### PR TITLE
fix: remove event start date validation, now validated only on backend

### DIFF
--- a/frontend/cypress/e2e/createEvent.cy.ts
+++ b/frontend/cypress/e2e/createEvent.cy.ts
@@ -660,14 +660,29 @@ describe('create event', () => {
       cy.get('[name=start]').type('2022-12-29')
       cy.get('[name=end]').type('2022-12-31')
 
+      cy.intercept(
+        { method: 'POST', pathname: '/api/frontend/events' },
+        {
+          statusCode: 400,
+          body: ['Nemůžeš vytvářet události v minulosti'],
+        },
+      ).as('createEvent')
+
+      cy.intercept('POST', '/api/frontend/events/1000/propagation/images/', {})
+      cy.intercept(
+        'POST',
+        '/api/frontend/events/1000/questionnaire/questions/',
+        {},
+      )
+
       submit()
 
       cy.get('[class^=SystemMessage_header]')
         .should('be.visible')
-        .contains('chyby ve validaci')
+        .contains('Nepodařilo se nám uložit akci')
       cy.get('[class^=SystemMessage_detail]')
         .should('be.visible')
-        .contains('Akci z minulého roku musíte uložit před koncem února')
+        .contains('Nemůžeš vytvářet události v minulosti')
     })
 
     it('before 03/01 allow saving event from past year', () => {
@@ -704,11 +719,26 @@ describe('create event', () => {
       cy.get('[name=start]').type('2021-12-29')
       cy.get('[name=end]').type('2021-12-31')
 
+      cy.intercept(
+        { method: 'POST', pathname: '/api/frontend/events' },
+        {
+          statusCode: 400,
+          body: ['Nemůžeš vytvářet události v minulosti'],
+        },
+      ).as('createEvent')
+
+      cy.intercept('POST', '/api/frontend/events/1000/propagation/images/', {})
+      cy.intercept(
+        'POST',
+        '/api/frontend/events/1000/questionnaire/questions/',
+        {},
+      )
+
       submit()
 
       cy.get('[class^=SystemMessage]')
-        .should('contain', 'chyby ve validaci')
-        .should('contain', 'Začátek akce:')
+        .should('contain', 'Nepodařilo se nám uložit akci')
+        .should('contain', 'Nemůžeš vytvářet události v minulosti')
     })
 
     context('admin or office_worker', () => {

--- a/frontend/src/org/components/EventForm/steps/BasicInfoStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/BasicInfoStep.tsx
@@ -15,8 +15,6 @@ import { useCurrentUser } from 'hooks/currentUser'
 import { useEffect } from 'react'
 import { Controller, FormProvider } from 'react-hook-form'
 import Select from 'react-select'
-import { getEventCannotBeOlderThan } from 'utils/helpers'
-import { canUserSaveOldEvent } from 'utils/roles'
 import * as validationMessages from 'utils/validationMessages'
 import { required } from 'utils/validationMessages'
 import { MethodsShapes } from '..'
@@ -53,8 +51,6 @@ export const BasicInfoStep = ({
   if (!(administrationUnits && categories && programs && currentUser))
     return <Loading>Připravujeme formulář</Loading>
 
-  const isAllowedToSaveOldEvents = canUserSaveOldEvent(currentUser)
-
   return (
     <FormProvider {...methods}>
       <form>
@@ -80,23 +76,12 @@ export const BasicInfoStep = ({
                     type="date"
                     id="start"
                     max={watch('end')}
-                    min={
-                      isAllowedToSaveOldEvents
-                        ? undefined
-                        : getEventCannotBeOlderThan()
-                    }
                     {...register('start', {
                       required,
                       max: {
                         value: watch('end'),
                         message: validationMessages.startBeforeEnd,
                       },
-                      min: isAllowedToSaveOldEvents
-                        ? undefined
-                        : {
-                            value: getEventCannotBeOlderThan(),
-                            message: validationMessages.oldEvent,
-                          },
                     })}
                   />
                 </FormInputError>


### PR DESCRIPTION
users could not create or edit events starting in previous year even though they would continue to this year

https://trello.com/c/4X6DpSei