### PR TITLE
fix: participants could not be queried by "surname name"

### DIFF
--- a/frontend/src/components/SelectUsers/SelectUsers.tsx
+++ b/frontend/src/components/SelectUsers/SelectUsers.tsx
@@ -150,6 +150,7 @@ export const SelectUnknownUser = forwardRef<
         isClearable
         options={userOptions ? userOptions : []}
         inputValue={searchQuery}
+        filterOption={() => true}
         onInputChange={input => setSearchQuery(input)}
         value={value}
         onChange={async user => {


### PR DESCRIPTION
react-select would filter options by their label which is not necessary due to them being searched on the backend, thus all items are displayed

https://trello.com/c/KuSbHkPB