### PR TITLE
fix: extended application table, better visibility on small screens

### DIFF
--- a/frontend/src/org/components/EventForm/steps/ParticipantsStep.module.scss
+++ b/frontend/src/org/components/EventForm/steps/ParticipantsStep.module.scss
@@ -15,16 +15,18 @@ h2 {
     transform: rotateX(.5turn);
   }
 
-  th:first-child,
-  td:first-child {
-    position: sticky;
-    left: 0;
-  }
+  @include media.for-tablet-portrait-up {
+    th:first-child,
+    td:first-child {
+      position: sticky;
+      left: 0;
+    }
 
-  th:last-child,
-  td:last-child {
-    position: sticky;
-    right: 0;
+    th:last-child,
+    td:last-child {
+      position: sticky;
+      right: 0;
+    }
   }
 }
 
@@ -228,6 +230,8 @@ h2 {
 
   td:first-child {
     z-index: 1;
+    position: sticky;
+    left: 0;
   }
 
   td:not(:first-child) {


### PR DESCRIPTION
https://trello.com/c/rG8ETush

@dag-mara Tohle je drobnost, ale ať o tom víš, kdybys předělávala tabulku účastníků: Na mobilních zařízeních nejsou ty sticky sloupce úplně nejlepší, protože pak překrývají celou šířku obrazovky a nedostaneš se k ostatním datům. Takže jsem je dal jen pro tablety a větší.