### PR TITLE
fix: save even invalid pages (close event)

### DIFF
--- a/frontend/src/org/pages/CloseEvent/CloseEventForm.tsx
+++ b/frontend/src/org/pages/CloseEvent/CloseEventForm.tsx
@@ -271,6 +271,7 @@ export const CloseEventForm = ({
         errors => {
           isValid = false
           evidenceErrors = errors
+          evidence = evidenceFormMethods.getValues()
         },
       )(),
       participantsFormMethods.handleSubmit(
@@ -280,6 +281,7 @@ export const CloseEventForm = ({
         errors => {
           isValid = false
           participantsErrors = errors
+          participants = participantsFormMethods.getValues()
         },
       )(),
     ])


### PR DESCRIPTION
https://trello.com/c/D0v5GdVz

To jsme tak v rámci jiného problému zjistili, že na akci nejdou nahrávat obrázky, pokud nejsou vyplněná povinná políčka (odpracované člověkohodiny a komentáře k práci). Podle specifikace se formulář může ukládat i nevalidní, pokud se akce neuzavírá. Což fungovalo, ale jen pro validní stránky. Tak jsem tam doplnil ještě funkci, která načte hodnoty z nevalidních stránek.