### PR TITLE
feat: form layout display form error only when necessary

### DIFF
--- a/frontend/src/components/FormInputError/FormInputError.module.scss
+++ b/frontend/src/components/FormInputError/FormInputError.module.scss
@@ -3,8 +3,8 @@
 .container {
   display: inline-block;
   position: relative;
-  top: calc((0.75rem + 4px) / 2);
   margin: 0 2px;
+  margin-top: calc((0.75rem + 4px) / 2);
 }
 
 .blockContainer {

--- a/frontend/src/components/FormInputError/FormInputError.tsx
+++ b/frontend/src/components/FormInputError/FormInputError.tsx
@@ -63,7 +63,9 @@ export const FormInputErrorSimple = ({
       >
         {children}
       </div>
-      <div className={styles.errorMessage}>{errorMessage ?? <>&nbsp;</>}</div>
+      {errorMessage && (
+        <div className={styles.errorMessage}>{errorMessage}</div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/FormLayout/FormLayout.module.scss
+++ b/frontend/src/components/FormLayout/FormLayout.module.scss
@@ -147,7 +147,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  align-items: center;
+  align-items: baseline;
   row-gap: 0;
   column-gap: 1rem;
 }


### PR DESCRIPTION
decreases form spacing
additional changes were necessary, since removing form error would break inline section alignment