### PR TITLE
Allow registration method for non-web events; decouple full from method

### DIFF
--- a/backend/event/migrations/0016_backfill_event_registration.py
+++ b/backend/event/migrations/0016_backfill_event_registration.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def create_default_registrations(apps, schema_editor):
+    Event = apps.get_model("event", "Event")
+    EventRegistration = apps.get_model("event", "EventRegistration")
+
+    missing = Event.objects.filter(registration__isnull=True)
+    EventRegistration.objects.bulk_create(
+        [EventRegistration(event=event) for event in missing]
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("event", "0015_eventrecord_is_event_closed_email_enabled"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_default_registrations, migrations.RunPython.noop),
+    ]

--- a/backend/event/migrations/0016_backfill_event_registration.py
+++ b/backend/event/migrations/0016_backfill_event_registration.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 
 def create_default_registrations(apps, schema_editor):
-    Event = apps.get_model("event", "Event")
+    Event = apps.get_model("bis", "Event")
     EventRegistration = apps.get_model("event", "EventRegistration")
 
     missing = Event.objects.filter(registration__isnull=True)

--- a/frontend/cypress/e2e/createEvent.cy.ts
+++ b/frontend/cypress/e2e/createEvent.cy.ts
@@ -719,6 +719,8 @@ const fillForm = () => {
     .should('be.visible')
     .check('false')
 
+  cy.get('[name=registrationMethod]').should('be.visible').check('none')
+
   next()
 
   cy.get('#react-select-7-input')

--- a/frontend/src/config/static/event.tsx
+++ b/frontend/src/config/static/event.tsx
@@ -66,14 +66,15 @@ export const form = {
   registrationMethod: {
     help: (
       <>
-        Způsoby přihlášení na vaši akci na www.brontosaurus.cz, které se zobrazí
-        po kliknutí na tlačítko “chci jet”:
+        Způsoby přihlášení na vaši akci, které se zobrazí po kliknutí na
+        tlačítko “chci jet” (na webu, nebo na sdíleném odkazu):
         <ul>
           <li>
             Standardní přihláška na brontowebu (doporučujeme!) - Je jednotná pro
             celé HB. Do této přihlášky si můžete přidat vlastní otázky. Vyplněné
             údaje se pak rovnou zobrazí v BIS, což tobě i kanceláři ulehčí
-            práci.
+            práci. Funguje i u akcí, které nezveřejňujete na webu - stačí
+            sdílet odkaz na přihlášku.
           </li>
           <li>
             Jiná elektronická přihláška - Při přihlašování budou zájemci rovnou
@@ -84,15 +85,15 @@ export const form = {
             Registrace není potřeba, stačí přijít - Zobrazí se jako text u tvojí
             akce na webu.
           </li>
-          <li>
-            Máme bohužel plno, zkuste jinou z našich akcí - Zobrazí se jako text
-            u tvojí akce na webu.
-          </li>
         </ul>
       </>
     ),
   },
   registration: {
+    is_event_full: {
+      name: 'Je akce plná',
+      help: 'Pokud zaškrtnete, účastníkům se zobrazí, že je akce plná. Způsob přihlášení i nastavení dotazníku zůstanou zachované, takže když se místo uvolní, stačí zaškrtnutí zrušit.',
+    },
     questionnaire: {
       help: 'Zde můžeš připsat svoje doplňující otevřené otázky pro účastníky, které se zobrazí u standardní přihlášky na webu. Kromě tvých otázek se standardní přihláška ptá na jméno, datum narození, telefon a email účastníka.',
       introduction: {

--- a/frontend/src/org/components/EventForm/EventForm.tsx
+++ b/frontend/src/org/components/EventForm/EventForm.tsx
@@ -81,7 +81,7 @@ export type EventFormShape = Assign<
     // we only keep track of whether to save location or online_link
     online: boolean
     // registrationMethod is internal, doesn't get sent to API
-    registrationMethod: 'standard' | 'other' | 'none' | 'full'
+    registrationMethod: 'standard' | 'other' | 'none'
     location: Location | NewLocation
   }
 >
@@ -189,7 +189,7 @@ const initialData2form = (
     data,
   ) as Partial<EventFormShape>
 
-  const registrationMethod = getRegistrationMethod(
+  const registrationMethod = getRegistrationMethodBeforeFull(
     merge({ registration: null }, data),
   )
 
@@ -249,7 +249,6 @@ const form2finalData = (data: EventFormShape): SubmitShape => {
         break
       case 'standard':
         finalData.registration.is_registration_required = true
-        finalData.registration.is_event_full = false
         finalData.registration.alternative_registration_link = ''
         // keep questionnaire set
         // set default value on questionnaire fields (can't be null)
@@ -262,15 +261,8 @@ const form2finalData = (data: EventFormShape): SubmitShape => {
         break
       case 'other':
         finalData.registration.is_registration_required = true
-        finalData.registration.is_event_full = false
         // keep alternative registration link set
         finalData.registration.questionnaire = null
-        break
-      case 'full':
-        finalData.registration.is_event_full = true
-        // everything else should equal initial data
-        // we need to take care of that in UpdateEvent
-        // or whatever component updates the data
         break
       default:
         break
@@ -309,7 +301,6 @@ const form2finalData = (data: EventFormShape): SubmitShape => {
 
   // data when not shown on web
   if (!data.propagation?.is_shown_on_web) {
-    finalData.registration = null
     finalData.propagation = null
   }
 
@@ -333,11 +324,21 @@ export const EventForm: FC<{
     | Partial<EventFormShape>
     | undefined
 
-  const initialAndSavedData: Partial<EventFormShape> = useMemo(
-    () =>
-      mergeWith(initialData2form(initialData), savedData, withOverwriteArray),
-    [initialData, savedData],
-  )
+  const initialAndSavedData: Partial<EventFormShape> = useMemo(() => {
+    const merged = mergeWith(
+      initialData2form(initialData),
+      savedData,
+      withOverwriteArray,
+    ) as Partial<EventFormShape>
+    // 'full' is no longer a valid registrationMethod — drop it from
+    // stale localStorage so the form re-derives from registration data
+    if ((merged.registrationMethod as string) === 'full') {
+      merged.registrationMethod = getRegistrationMethodBeforeFull(
+        merged as Pick<Event, 'registration'>,
+      ) as EventFormShape['registrationMethod']
+    }
+    return merged
+  }, [initialData, savedData])
 
   const groupForm = useForm({
     defaultValues: pick(initialAndSavedData, shapes.group),

--- a/frontend/src/org/components/EventForm/steps/RegistrationStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/RegistrationStep.tsx
@@ -27,7 +27,9 @@ export const RegistrationStep = ({
 }) => {
   const { control, register, watch } = methods
 
-  const isNotOnWeb = watch('propagation.is_shown_on_web') === false
+  const registrationMethod = watch('registrationMethod')
+  const canBeFull =
+    registrationMethod === 'standard' || registrationMethod === 'other'
 
   const [showInfo, setShowInfo] = useState(false)
   const handleClickShowInfo = () => {
@@ -83,48 +85,58 @@ export const RegistrationStep = ({
             </FormInputError>
           </FormSection>
 
-          {!isNotOnWeb && (
-            <>
-              <FormSection
-                header="Způsob přihlášení"
-                required
-                onWeb
-                help={formTexts.registrationMethod.help}
-              >
-                <FormInputError name="registrationMethod">
-                  <fieldset>
-                    {[
-                      {
-                        name: 'Standardní přihláška na brontowebu',
-                        value: 'standard',
-                      },
-                      { name: 'Jiná elektronická přihláška', value: 'other' },
-                      {
-                        name: 'Registrace není potřeba, stačí přijít',
-                        value: 'none',
-                      },
-                      {
-                        name: 'Máme bohužel plno, zkuste jinou z našich akcí',
-                        value: 'full',
-                      },
-                    ].map(({ name, value }) => (
-                      <label key={value} className="radioLabel">
-                        <input
-                          type="radio"
-                          value={value}
-                          id={`registration-method-${value}`}
-                          {...register('registrationMethod', {
-                            required: messages.required,
-                          })}
-                        />{' '}
-                        {name}
-                      </label>
-                    ))}
-                  </fieldset>
-                </FormInputError>
-              </FormSection>
+          <FormSection
+            header="Způsob přihlášení"
+            required
+            help={formTexts.registrationMethod.help}
+          >
+            <FormInputError name="registrationMethod">
+              <fieldset>
+                {[
+                  {
+                    name: 'Standardní přihláška na brontowebu',
+                    value: 'standard',
+                  },
+                  { name: 'Jiná elektronická přihláška', value: 'other' },
+                  {
+                    name: 'Registrace není potřeba, stačí přijít',
+                    value: 'none',
+                  },
+                ].map(({ name, value }) => (
+                  <label key={value} className="radioLabel">
+                    <input
+                      type="radio"
+                      value={value}
+                      id={`registration-method-${value}`}
+                      {...register('registrationMethod', {
+                        required: messages.required,
+                      })}
+                    />{' '}
+                    {name}
+                  </label>
+                ))}
+              </fieldset>
+            </FormInputError>
+          </FormSection>
 
-              {watch('registrationMethod') === 'other' && (
+          {canBeFull && (
+            <FormSection
+              header={formTexts.registration.is_event_full.name}
+              help={formTexts.registration.is_event_full.help}
+            >
+              <FormInputError>
+                <label className="checkboxLabel">
+                  <input
+                    type="checkbox"
+                    {...register('registration.is_event_full')}
+                  />{' '}
+                  Máme bohužel plno, zkuste jinou z našich akcí
+                </label>
+              </FormInputError>
+            </FormSection>
+          )}
+
+          {watch('registrationMethod') === 'other' && (
                 <InlineSection>
                   <InfoBox>
                     Opravdu nechcete použít Standardní přihlášku?
@@ -260,8 +272,6 @@ export const RegistrationStep = ({
                   <QuestionsFormSection methods={methods} />
                 </FormSubsection>
               )}
-            </>
-          )}
         </FormSectionGroup>
       </form>
     </FormProvider>

--- a/frontend/src/org/pages/UpdateEvent.tsx
+++ b/frontend/src/org/pages/UpdateEvent.tsx
@@ -104,7 +104,6 @@ export const UpdateEvent = () => {
   if (isSubmitting) return <Loading>Ukládáme změny</Loading>
 
   const { images, questions } = event
-  const initialEvent = event
 
   const handleSubmit: Parameters<typeof EventForm>[0]['onSubmit'] = async ({
     main_image: updatedMainImage,
@@ -122,13 +121,6 @@ export const UpdateEvent = () => {
         delete event.record.comment_on_work_done
       if (event.record?.total_hours_worked === null)
         delete event.record.total_hours_worked
-
-      // make sure we save initial registration data when is_event_full
-      if (event.registration?.is_event_full) {
-        event.registration = merge({}, initialEvent.registration, {
-          is_event_full: true,
-        })
-      }
 
       // update event
       const updatedEvent = await updateEvent({

--- a/frontend/src/pages/EventRegistration/EventRegistration.tsx
+++ b/frontend/src/pages/EventRegistration/EventRegistration.tsx
@@ -84,6 +84,11 @@ export const EventRegistration = () => {
 
   const registrationMethod = getRegistrationMethod(event)
 
+  if (registrationMethod === 'none')
+    return (
+      <Error message="Na tuto akci se nemusíte přihlašovat. Stačí přijít."></Error>
+    )
+
   if (registrationMethod === 'full')
     return (
       <Error message="Tato akce je plná">
@@ -91,11 +96,6 @@ export const EventRegistration = () => {
           Zkuste jinou z našich akcí
         </a>
       </Error>
-    )
-
-  if (registrationMethod === 'none')
-    return (
-      <Error message="Na tuto akci se nemusíte přihlašovat. Stačí přijít."></Error>
     )
 
   // when alternative registration link is set, redirect there


### PR DESCRIPTION
## Summary
- Step 5 of the event form ("Přihlášení") now shows the **Způsob přihlášení** radio regardless of whether the event is published on www.brontosaurus.cz, so organizers can use the standard brontoweb application form for unlisted events.
- "Máme bohužel plno" is split out of the registration-method radio into its own **Akce je plná** checkbox bound to `registration.is_event_full`. Marking an event full no longer overwrites the chosen registration method, and unmarking it restores access without any special re-merge in `UpdateEvent`. The checkbox is hidden when registration method is `none` (no-registration events can't be "full" in the application sense).
- `form2finalData` no longer nulls `registration` when the event isn't on the web — only `propagation` gets nulled. A backfill data migration creates default `EventRegistration` rows for any event whose registration was previously wiped, so they don't show as invalid in the form on next edit.
- Persisted form data containing the now-removed `registrationMethod: 'full'` is sanitized on load and re-derived from the underlying registration data.

## Test plan
- [ ] Create an event with `Zveřejnit na webu = Ne`; confirm the registration-method radio is visible and required.
- [ ] Pick `Standardní přihláška na brontowebu` for a non-web event, save, reload — confirm round-trip and that the standard application URL works.
- [ ] On a public event, pick `standard`, then check `Akce je plná`; save and reload — confirm both the radio and the checkbox come back populated and `EventRegistration.tsx` shows the full message to participants.
- [ ] Toggle the full checkbox off and confirm registrations open up again without the org needing to re-pick a method.
- [ ] Switch registration method to `none` — the full checkbox disappears.
- [ ] Run `python manage.py migrate event` and verify that events that were previously `propagation = NULL, registration = NULL` now have an `EventRegistration` row with defaults (`is_registration_required=True`, `is_event_full=False`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)