### PR TITLE
Cap pagination and loop fetch-all callers to fix Django OOM

### DIFF
--- a/backend/administration_units/signals.py
+++ b/backend/administration_units/signals.py
@@ -1,6 +1,7 @@
 from administration_units.models import AdministrationUnit, BrontosaurusMovement
+from bis.cache import invalidate_cache
 from bis.models import User
-from django.db.models.signals import m2m_changed, post_save
+from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 from event.models import Event
 
@@ -13,6 +14,18 @@ def set_board_members(instance, **kwargs):
         instance.board_members.add(instance.vice_chairman)
     if instance.manager:
         instance.board_members.add(instance.manager)
+
+
+@receiver(
+    post_save, sender=AdministrationUnit, dispatch_uid="invalidate_admin_units_save"
+)
+@receiver(
+    post_delete,
+    sender=AdministrationUnit,
+    dispatch_uid="invalidate_admin_units_delete",
+)
+def invalidate_administration_units_cache(**kwargs):
+    invalidate_cache("administration_units")
 
 
 @receiver(

--- a/backend/api/frontend/filters.py
+++ b/backend/api/frontend/filters.py
@@ -22,6 +22,9 @@ class UserFilter(django_filters.FilterSet):
 
 class EventFilter(django_filters.FilterSet):
     id = NumberInFilter()
+    is_archived = django_filters.BooleanFilter()
+    is_closed = django_filters.BooleanFilter()
+    is_canceled = django_filters.BooleanFilter()
 
     class Meta:
         model = Event

--- a/backend/api/frontend/permissions.py
+++ b/backend/api/frontend/permissions.py
@@ -9,7 +9,7 @@ class BISPermissions(BasePermission):
     def has_object_permission(self, request, view, obj):
         perms = Permissions(request.user, view.serializer_class.Meta.model, "frontend")
 
-        if view.action in ["retrieve", "list"]:
+        if view.action in ["retrieve", "list", "for_map"]:
             return perms.has_view_permission(obj)
 
         if view.action in ["create"]:

--- a/backend/api/frontend/serializers.py
+++ b/backend/api/frontend/serializers.py
@@ -758,6 +758,16 @@ class LocationPatronSerializer(BaseContactSerializer):
         model = LocationPatron
 
 
+class LocationMapSerializer(ModelSerializer):
+    class Meta:
+        model = Location
+        fields = (
+            "id",
+            "name",
+            "gps_location",
+        )
+
+
 class LocationSerializer(ModelSerializer):
     patron = LocationPatronSerializer(allow_null=True)
     contact_person = LocationContactPersonSerializer(allow_null=True)

--- a/backend/api/frontend/views.py
+++ b/backend/api/frontend/views.py
@@ -18,6 +18,7 @@ from api.frontend.serializers import (
     GetUserByEmailRequestSerializer,
     GetUserByEmailResponseSerializer,
     InquirySerializer,
+    LocationMapSerializer,
     LocationSerializer,
     OpportunitySerializer,
     QuestionSerializer,
@@ -25,7 +26,7 @@ from api.frontend.serializers import (
     UserSearchSerializer,
     UserSerializer,
 )
-from api.helpers import parse_request_data
+from api.helpers import LightPagination, parse_request_data
 from bis.helpers import filter_queryset_with_multiple_or_queries
 from bis.models import Location, User
 from bis.permissions import Permissions
@@ -48,7 +49,7 @@ from login_code.models import get_unknown_user_throttle
 from opportunities.models import Opportunity
 from other.models import Announcement, DashboardItem
 from questionnaire.models import EventApplication, Question
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin
@@ -247,6 +248,23 @@ class LocationViewSet(PermissionViewSetBase):
         "accessibility_from_prague",
         "accessibility_from_brno",
     )
+
+    @action(
+        detail=False,
+        methods=["get"],
+        pagination_class=LightPagination,
+        filter_backends=[],
+    )
+    def for_map(self, request):
+        queryset = (
+            self.get_queryset()
+            .select_related(None)
+            .exclude(gps_location__isnull=True)
+            .only("id", "name", "gps_location")
+        )
+        page = self.paginate_queryset(queryset)
+        serializer = LocationMapSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
 
 
 class OpportunityViewSet(PermissionViewSetBase):

--- a/backend/api/helpers.py
+++ b/backend/api/helpers.py
@@ -18,6 +18,11 @@ from rest_framework.serializers import ModelSerializer
 
 class Pagination(PageNumberPagination):
     page_size_query_param = "page_size"
+    max_page_size = 200
+
+
+class LightPagination(Pagination):
+    max_page_size = 1000
 
 
 def parse_request_data(serializer_class, data_name="data"):

--- a/backend/api/web/views.py
+++ b/backend/api/web/views.py
@@ -5,6 +5,7 @@ from api.web.serializers import (
     EventSerializer,
     OpportunitySerializer,
 )
+from bis.cache import CachedViewSetMixin
 from django.http import Http404
 from django.utils.timezone import now
 from event.models import Event
@@ -85,7 +86,8 @@ class OpportunityViewSet(ReadOnlyModelViewSet):
         )
 
 
-class AdministrationUnitViewSet(ReadOnlyModelViewSet):
+class AdministrationUnitViewSet(CachedViewSetMixin, ReadOnlyModelViewSet):
+    cache_namespace = "administration_units"
     queryset = (
         AdministrationUnit.objects.filter(
             existed_till__isnull=True,

--- a/frontend/cypress/e2e/createEvent.cy.ts
+++ b/frontend/cypress/e2e/createEvent.cy.ts
@@ -51,23 +51,29 @@ describe('create event', () => {
         },
       ],
     })
-    cy.intercept('GET', '/api/frontend/locations/\\?*', { results: locations })
-    cy.intercept('GET', '/api/frontend/search_users/?search=*', req => {
-      req.reply({
-        results: searchUsers
-          .filter(user =>
-            (
-              user.display_name +
-              user.first_name +
-              user.last_name +
-              user.nickname
+    cy.intercept(
+      { method: 'GET', pathname: '/api/frontend/locations/' },
+      { results: locations },
+    )
+    cy.intercept(
+      { method: 'GET', pathname: '/api/frontend/search_users/' },
+      req => {
+        req.reply({
+          results: searchUsers
+            .filter(user =>
+              (
+                user.display_name +
+                user.first_name +
+                user.last_name +
+                user.nickname
+              )
+                .toLowerCase()
+                .includes((req.query.search as string).toLowerCase()),
             )
-              .toLowerCase()
-              .includes((req.query.search as string).toLowerCase()),
-          )
-          .slice(5),
-      })
-    })
+            .slice(5),
+        })
+      },
+    )
     cy.intercept(
       { method: 'GET', pathname: '/api/frontend/users/' },
       { results: [] },

--- a/frontend/src/app/services/bis.ts
+++ b/frontend/src/app/services/bis.ts
@@ -22,8 +22,8 @@
 // Need to use the React-specific entry point to import createApi
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { RootState } from 'app/store'
-import { ClearBounds } from 'components'
 import dayjs from 'dayjs'
+import { fetchAllPages } from './fetchAllPages'
 import type { Assign, Overwrite } from 'utility-types'
 import type {
   AdministrationUnit,
@@ -60,7 +60,6 @@ import type {
   Question,
   Questionnaire,
   Record,
-  Region,
   Registration,
   TokenResponse,
   User,
@@ -74,8 +73,6 @@ import {
   FeedbackForm,
   Inquiry,
 } from './testApi'
-
-export const ALL_USERS = 2000
 
 // Define a service using a base URL and expected endpoints
 export const api = createApi({
@@ -179,17 +176,35 @@ export const api = createApi({
     }),
     readUsers: build.query<
       PaginatedList<User>,
-      ListArguments & { id?: string[]; _search_id?: string[] }
+      { id?: string[]; _search_id?: string[]; search?: string }
     >({
-      query: ({ id, _search_id, ...params }) => ({
-        url: `frontend/users/`,
-        params: {
-          id: id?.join?.(','),
-          _search_id: _search_id?.join?.(','),
-          page_size: params.pageSize,
-          ...params,
-        },
-      }),
+      queryFn: async (arg, api, extraOptions, baseQuery) => {
+        // An empty id/_search_id list means "no users match"; without this
+        // guard the empty filter would be sent to DRF and ignored, returning
+        // every visible user and looping forever for superusers.
+        if (
+          (arg.id !== undefined && arg.id.length === 0) ||
+          (arg._search_id !== undefined && arg._search_id.length === 0)
+        ) {
+          return { data: { count: 0, next: null, previous: null, results: [] } }
+        }
+        return fetchAllPages<typeof arg>({
+          buildArgs: ({ page, pageSize, arg }) => ({
+            url: `frontend/users/`,
+            params: {
+              id: arg.id?.join?.(','),
+              _search_id: arg._search_id?.join?.(','),
+              search: arg.search,
+              page,
+              page_size: pageSize,
+            },
+          }),
+          // Search caps matches so a vague term doesn't fan out into many
+          // pages; id/_search_id lookups stay unbounded because the caller
+          // has an exact list and expects every row back.
+          maxItems: a => (a.search ? 200 : undefined),
+        })<User>(arg, api, extraOptions, baseQuery)
+      },
       providesTags: results =>
         results?.results
           ? results.results.map(user => ({
@@ -204,14 +219,13 @@ export const api = createApi({
      * but searches the whole user database,
      * not just users visible to current user
      */
-    readAllUsers: build.query<PaginatedList<UserSearch>, ListArguments>({
-      query: queryArg => ({
-        url: `frontend/search_users/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+    readAllUsers: build.query<PaginatedList<UserSearch>, { search?: string }>({
+      queryFn: fetchAllPages<{ search?: string }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/search_users/`,
+          params: { page, page_size: pageSize, search: arg.search },
+        }),
+        maxItems: arg => (arg.search ? 200 : undefined),
       }),
       providesTags: results =>
         results?.results
@@ -241,124 +255,107 @@ export const api = createApi({
      * Read various categories
      */
     readEventCategories: build.query<PaginatedList<EventCategory>, void>({
-      query: () => ({
-        url: `categories/event_categories/`,
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/event_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readEventGroups: build.query<PaginatedList<EventGroupCategory>, void>({
-      query: () => ({
-        url: `categories/event_group_categories/`,
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/event_group_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readPrograms: build.query<PaginatedList<EventProgramCategory>, void>({
-      query: () => ({
-        url: `categories/event_program_categories/`,
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/event_program_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readIntendedFor: build.query<PaginatedList<EventIntendedForCategory>, void>(
       {
-        query: () => ({
-          url: `categories/event_intended_for_categories/`,
+        queryFn: fetchAllPages<void>({
+          buildArgs: ({ page, pageSize }) => ({
+            url: `categories/event_intended_for_categories/`,
+            params: { page, page_size: pageSize },
+          }),
         }),
       },
     ),
     readDiets: build.query<PaginatedList<DietCategory>, void>({
-      query: () => ({
-        url: `categories/diet_categories/`,
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/diet_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readAdministrationUnits: build.query<
       PaginatedList<AdministrationUnit>,
-      ListArguments & {
-        /** Více hodnot lze oddělit čárkami. */
-        category?: (
-          | 'basic_section'
-          | 'club'
-          | 'headquarter'
-          | 'regional_center'
-        )[]
-      }
+      void
     >({
-      query: queryArg => ({
-        url: `web/administration_units/`,
-        params: {
-          category: queryArg.category,
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `web/administration_units/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
-    readQualifications: build.query<
-      PaginatedList<QualificationCategory>,
-      ListArguments
-    >({
-      query: queryArg => ({
-        url: `categories/qualification_categories/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
-      }),
-    }),
-    readPronouns: build.query<PaginatedList<PronounCategory>, ListArguments>({
-      query: queryArg => ({
-        url: `categories/pronoun_categories/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
-      }),
-    }),
-    readRegions: build.query<PaginatedList<Region>, ListArguments>({
-      query: queryArg => ({
-        url: `categories/regions/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+    readQualifications: build.query<PaginatedList<QualificationCategory>, void>(
+      {
+        queryFn: fetchAllPages<void>({
+          buildArgs: ({ page, pageSize }) => ({
+            url: `categories/qualification_categories/`,
+            params: { page, page_size: pageSize },
+          }),
+        }),
+      },
+    ),
+    readPronouns: build.query<PaginatedList<PronounCategory>, void>({
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/pronoun_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readHealthInsuranceCompanies: build.query<
       PaginatedList<HealthInsuranceCompany>,
-      ListArguments
+      void
     >({
-      query: queryArg => ({
-        url: `categories/health_insurance_companies/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/health_insurance_companies/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readOpportunityCategories: build.query<
       PaginatedList<OpportunityCategory>,
-      ListArguments
+      void
     >({
-      query: queryArg => ({
-        url: `categories/opportunity_categories/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/opportunity_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readMembershipCategories: build.query<
       PaginatedList<MembershipCategory>,
-      ListArguments
+      void
     >({
-      query: queryArg => ({
-        url: `categories/membership_categories/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/membership_categories/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
 
@@ -377,21 +374,19 @@ export const api = createApi({
     }),
     readLocations: build.query<
       PaginatedList<Location>,
-      {
-        /** Více hodnot lze oddělit čárkami. */
-        id?: number[]
-        // This doesn't exist, but we want it!
-        bounds?: ClearBounds
-      } & ListArguments
+      { id?: number[]; search?: string }
     >({
-      query: queryArg => ({
-        url: `frontend/locations/`,
-        params: {
-          id: queryArg.id,
-          page: queryArg.page,
-          page_size: queryArg.bounds ? 5000 : queryArg.pageSize, // this will fetch everything (cry)
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ id?: number[]; search?: string }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/locations/`,
+          params: {
+            id: arg.id?.join?.(','),
+            search: arg.search,
+            page,
+            page_size: pageSize,
+          },
+        }),
+        maxItems: arg => (arg.search ? 200 : undefined),
       }),
       providesTags: results =>
         (results?.results
@@ -404,6 +399,19 @@ export const api = createApi({
             )
           : []
         ).concat([{ type: 'Location' as const, id: 'LOCATION_LIST' }]),
+    }),
+    readLocationsForMap: build.query<
+      PaginatedList<Pick<Location, 'id' | 'name' | 'gps_location'>>,
+      void
+    >({
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `frontend/locations/for_map/`,
+          params: { page, page_size: pageSize },
+        }),
+        pageSize: 500,
+      }),
+      providesTags: () => [{ type: 'Location' as const, id: 'LOCATION_LIST' }],
     }),
     readLocation: build.query<Location, { id: number }>({
       query: queryArg => ({ url: `frontend/locations/${queryArg.id}/` }),
@@ -521,7 +529,13 @@ export const api = createApi({
     }),
     readOrganizedEvents: build.query<
       PaginatedList<Event>,
-      { userId: string; id?: number[] } & ListArguments
+      {
+        userId: string
+        id?: number[]
+        is_archived?: boolean
+        is_closed?: boolean
+        is_canceled?: boolean
+      } & ListArguments
     >({
       query: queryArg => ({
         url: `frontend/users/${queryArg.userId}/events_where_was_organizer/`,
@@ -530,6 +544,9 @@ export const api = createApi({
           page: queryArg.page,
           page_size: queryArg.pageSize,
           search: queryArg.search,
+          is_archived: queryArg.is_archived,
+          is_closed: queryArg.is_closed,
+          is_canceled: queryArg.is_canceled,
         },
       }),
       providesTags: results =>
@@ -592,15 +609,13 @@ export const api = createApi({
     }),
     readEventImages: build.query<
       PaginatedList<EventPropagationImage>,
-      { eventId: number } & ListArguments
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/propagation/images/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/propagation/images/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) =>
         results?.results
@@ -658,15 +673,13 @@ export const api = createApi({
     }),
     readEventQuestions: build.query<
       PaginatedList<Question>,
-      { eventId: number } & ListArguments
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/registration/questionnaire/questions/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/registration/questionnaire/questions/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) =>
         results?.results
@@ -728,15 +741,13 @@ export const api = createApi({
     }),
     readEventFeedbackInquiries: build.query<
       PaginatedList<InquiryRead>,
-      { eventId: number } & ListArguments
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `/frontend/events/${queryArg.eventId}/feedback_form/inquiries/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `/frontend/events/${arg.eventId}/feedback_form/inquiries/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) =>
         results?.results
@@ -806,15 +817,13 @@ export const api = createApi({
     }),
     readFinanceReceipts: build.query<
       PaginatedList<FinanceReceipt>,
-      ListArguments & { eventId: number }
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/finance/receipts/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/finance/receipts/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) =>
         results?.results
@@ -876,16 +885,13 @@ export const api = createApi({
     }),
     readEventFeedbacks: build.query<
       PaginatedList<EventFeedbackRead>,
-      { eventId: number } & ListArguments
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/feedbacks/`,
-        method: 'GET',
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/feedbacks/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) => [
         { type: 'Feedback', id: `${eventId}_FEEDBACK_LIST` },
@@ -915,11 +921,11 @@ export const api = createApi({
       PaginatedList<EventApplication>,
       { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/registration/applications/`,
-        params: {
-          page_size: 10000,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/registration/applications/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: results =>
         (results?.results
@@ -981,15 +987,13 @@ export const api = createApi({
     }),
     readEventParticipants: build.query<
       PaginatedList<User>,
-      { eventId: number } & ListArguments
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/record/participants/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/record/participants/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: results =>
         (results?.results
@@ -1020,15 +1024,13 @@ export const api = createApi({
     // }),
     readAttendanceListPages: build.query<
       PaginatedList<AttendanceListPage>,
-      ListArguments & { eventId: number }
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/record/attendance_list_pages/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/record/attendance_list_pages/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) =>
         results?.results
@@ -1104,15 +1106,13 @@ export const api = createApi({
     }),
     readEventPhotos: build.query<
       PaginatedList<EventPhoto>,
-      ListArguments & { eventId: number }
+      { eventId: number }
     >({
-      query: queryArg => ({
-        url: `frontend/events/${queryArg.eventId}/record/photos/`,
-        params: {
-          page: queryArg.page,
-          page_size: queryArg.pageSize,
-          search: queryArg.search,
-        },
+      queryFn: fetchAllPages<{ eventId: number }>({
+        buildArgs: ({ page, pageSize, arg }) => ({
+          url: `frontend/events/${arg.eventId}/record/photos/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
       providesTags: (results, error, { eventId }) =>
         results?.results
@@ -1189,11 +1189,11 @@ export const api = createApi({
       }),
     }),
     readDashboardItems: build.query<PaginatedList<DashboardItem>, void>({
-      query: () => ({
-        url: '/frontend/dashboard_items/',
-        params: {
-          page_size: 1000,
-        },
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: '/frontend/dashboard_items/',
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
     readAnnouncements: build.query<Announcement[], void>({
@@ -1229,8 +1229,11 @@ export const api = createApi({
     }),
 
     readEventTags: build.query<PaginatedList<EventTag>, void>({
-      query: () => ({
-        url: `categories/event_tags/`,
+      queryFn: fetchAllPages<void>({
+        buildArgs: ({ page, pageSize }) => ({
+          url: `categories/event_tags/`,
+          params: { page, page_size: pageSize },
+        }),
       }),
     }),
   }),

--- a/frontend/src/app/services/fetchAllPages.ts
+++ b/frontend/src/app/services/fetchAllPages.ts
@@ -1,0 +1,79 @@
+import type {
+  FetchArgs,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+} from '@reduxjs/toolkit/query'
+import type {
+  BaseQueryApi,
+  QueryReturnValue,
+} from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import type { MaybePromise } from '@reduxjs/toolkit/dist/query/tsHelpers'
+import type { PaginatedList } from './bisTypes'
+
+const DEFAULT_PAGE_SIZE = 100
+
+/**
+ * Fetches every page of a paginated DRF endpoint in parallel.
+ * Page 1 reveals `count`; pages 2..N are fired concurrently.
+ * The browser caps concurrent connections per origin (~6), so the loop
+ * stays bounded without an explicit limiter.
+ *
+ * Use as `queryFn:` on an RTK Query endpoint that needs every row.
+ */
+export const fetchAllPages =
+  <TArg>(opts: {
+    buildArgs: (params: {
+      page: number
+      pageSize: number
+      arg: TArg
+    }) => FetchArgs | string
+    pageSize?: number
+    maxItems?: (arg: TArg) => number | undefined
+  }) =>
+  async <TItem>(
+    arg: TArg,
+    _api: BaseQueryApi,
+    _extraOptions: unknown,
+    baseQuery: (
+      args: FetchArgs | string,
+    ) => MaybePromise<
+      QueryReturnValue<unknown, FetchBaseQueryError, FetchBaseQueryMeta>
+    >,
+  ): Promise<
+    QueryReturnValue<PaginatedList<TItem>, FetchBaseQueryError, object>
+  > => {
+    const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE
+    const maxItems = opts.maxItems?.(arg)
+
+    const first = await baseQuery(opts.buildArgs({ page: 1, pageSize, arg }))
+    if (first.error) return { error: first.error }
+    const firstData = first.data as PaginatedList<TItem>
+
+    if (!firstData.next) return { data: firstData }
+
+    let totalPages = Math.ceil(firstData.count / pageSize)
+    if (maxItems !== undefined) {
+      totalPages = Math.min(totalPages, Math.ceil(maxItems / pageSize))
+    }
+    if (totalPages <= 1) return { data: firstData }
+
+    const restPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2)
+    const responses = await Promise.all(
+      restPages.map(page => baseQuery(opts.buildArgs({ page, pageSize, arg }))),
+    )
+
+    const results: TItem[] = [...firstData.results]
+    for (const response of responses) {
+      if (response.error) return { error: response.error }
+      results.push(...(response.data as PaginatedList<TItem>).results)
+    }
+
+    return {
+      data: {
+        count: firstData.count,
+        next: null,
+        previous: null,
+        results: maxItems !== undefined ? results.slice(0, maxItems) : results,
+      },
+    }
+  }

--- a/frontend/src/app/services/fetchAllPages.ts
+++ b/frontend/src/app/services/fetchAllPages.ts
@@ -13,7 +13,6 @@ import type { PaginatedList } from './bisTypes'
 const DEFAULT_PAGE_SIZE = 100
 
 /**
- * Fetches every page of a paginated DRF endpoint in parallel.
  * Page 1 reveals `count`; pages 2..N are fired concurrently.
  * The browser caps concurrent connections per origin (~6), so the loop
  * stays bounded without an explicit limiter.

--- a/frontend/src/components/PaginatedList/PaginatedList.tsx
+++ b/frontend/src/components/PaginatedList/PaginatedList.tsx
@@ -1,44 +1,42 @@
 import classNames from 'classnames'
 import { Pagination } from 'components'
-import { useSearchParamsState } from 'hooks/searchParamsState'
 import { FC } from 'react'
 
-/**
- * It's unscalable, because we have to provide all the data at the beginning
- * So when there are many items to list, we have to download them all at once
- *
- * We can provide additional props for table in this component
- */
-export const UnscalablePaginatedList = <T, C extends object = object>({
+export const PAGE_SIZE = 10
+
+export const PaginatedList = <T, C extends object = object>({
   data,
+  totalCount,
+  page,
+  pageSize,
+  onPageChange,
   table,
   className,
-  pageSize = 10,
   columnsToHideOnMobile,
   ...rest
 }: {
   data: T[]
+  totalCount: number
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
   table: FC<{ data: T[] } & C>
   className?: string
-  pageSize?: number
   columnsToHideOnMobile?: number[]
 } & C) => {
-  const [page, setPage] = useSearchParamsState('s', 1, Number)
   const Table = table
-
-  const tableData = data.slice((page - 1) * pageSize, page * pageSize)
 
   return (
     <div className={classNames(className)}>
       <Table
-        data={tableData}
+        data={data}
         {...(rest as unknown as C)}
         columnsToHideOnMobile={columnsToHideOnMobile}
       />
       <Pagination
         page={page}
-        pages={Math.max(1, Math.ceil((data.length as number) / pageSize))}
-        onPageChange={setPage}
+        pages={Math.max(1, Math.ceil(totalCount / pageSize))}
+        onPageChange={onPageChange}
       />
     </div>
   )

--- a/frontend/src/components/SelectLocation/SelectLocation.tsx
+++ b/frontend/src/components/SelectLocation/SelectLocation.tsx
@@ -5,7 +5,6 @@ import type { Location } from 'app/services/bisTypes'
 import classNames from 'classnames'
 import {
   Button,
-  ClearBounds,
   FormInputError,
   FormInputErrorSimple,
   InfoBox,
@@ -91,10 +90,12 @@ export const SelectLocation = forwardRef<
   }
 >(({ value, onChange, errorMessage, colorTheme }, ref) => {
   const [isEditing, setIsEditing] = useState(false)
-  const [bounds, setBounds] = useState<ClearBounds>()
 
-  const { data: locations, isLoading } = api.endpoints.readLocations.useQuery(
-    bounds ? { pageSize: 5000 } : skipToken,
+  const { data: locations, isLoading } =
+    api.endpoints.readLocationsForMap.useQuery(undefined)
+
+  const { data: selectedFullLocation } = api.endpoints.readLocation.useQuery(
+    value && 'id' in value ? { id: value.id } : skipToken,
   )
 
   const newLocationMethods = useForm<NewLocation>({
@@ -108,7 +109,8 @@ export const SelectLocation = forwardRef<
       ),
     [locations],
   )
-  const selectedLocation = value
+  const selectedLocation =
+    value && 'id' in value ? (selectedFullLocation ?? value) : value
 
   // here we hold the coordinates of new location in map
   const [newLocationCoordinates, setNewLocationCoordinates] = useState<
@@ -158,7 +160,7 @@ export const SelectLocation = forwardRef<
           type: 'selected',
           name: selectedLocation.name,
           coordinates,
-          id: 'id' in selectedLocation ? selectedLocation.id : 0,
+          id: value.id,
         })
       }
     } else if (!isEditing && value?.name && value?.gps_location?.coordinates) {
@@ -183,9 +185,8 @@ export const SelectLocation = forwardRef<
 
   const handleSelect = (id: number) => {
     setIsEditing(false)
-    onChange(
-      locations!.results.find(location => location.id === id) as Location,
-    )
+    const found = locations!.results.find(location => location.id === id)
+    if (found) onChange(found as Location)
   }
 
   // do this when CreateLocation is finished
@@ -304,7 +305,6 @@ export const SelectLocation = forwardRef<
                   }
                 }}
                 onSelect={handleSelect}
-                onChangeBounds={bounds => setBounds(bounds)}
                 editMode={isEditing}
               />
             </Suspense>

--- a/frontend/src/components/SelectUsers/SelectUsers.tsx
+++ b/frontend/src/components/SelectUsers/SelectUsers.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { FetchBaseQueryError, skipToken } from '@reduxjs/toolkit/query'
-import { ALL_USERS, api } from 'app/services/bis'
+import { api } from 'app/services/bis'
 import { User, UserSearch } from 'app/services/bisTypes'
 import {
   Actions,
@@ -44,7 +44,6 @@ export const SelectFullUsers = forwardRef<any, SelectObjectsProps<User>>(
         debouncedSearchQuery.length >= 2
           ? {
               search: debouncedSearchQuery,
-              pageSize: ALL_USERS,
             }
           : skipToken,
       )
@@ -93,7 +92,6 @@ export const SelectFullUser = forwardRef<any, SelectObjectProps<User>>(
         debouncedSearchQuery.length >= 2
           ? {
               search: debouncedSearchQuery,
-              pageSize: ALL_USERS,
             }
           : skipToken,
       )

--- a/frontend/src/components/UserForm/UserForm.tsx
+++ b/frontend/src/components/UserForm/UserForm.tsx
@@ -274,9 +274,9 @@ export const UserForm = ({
   const showMessage = useShowMessage()
 
   // fetch data for form
-  const { data: pronouns } = api.endpoints.readPronouns.useQuery({})
+  const { data: pronouns } = api.endpoints.readPronouns.useQuery(undefined)
   const { data: healthInsuranceCompanies } =
-    api.endpoints.readHealthInsuranceCompanies.useQuery({ pageSize: 1000 })
+    api.endpoints.readHealthInsuranceCompanies.useQuery(undefined)
 
   const persistedData = usePersistentFormData('user', id)
 

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -51,7 +51,10 @@ export { MapyCzSearch } from './MapyCzSearch/MapyCzSearch'
 export { NumberInput } from './NumberInput/NumberInput'
 export { OSMSearch } from './OSMSearch/OSMSearch'
 export { PageHeader } from './PageHeader/PageHeader'
-export { UnscalablePaginatedList } from './PaginatedList/PaginatedList'
+export {
+  PAGE_SIZE as PAGINATED_LIST_PAGE_SIZE,
+  PaginatedList,
+} from './PaginatedList/PaginatedList'
 export { Pagination } from './Pagination/Pagination'
 export { htmlRequired, RichTextEditor } from './RichTextEditor/RichTextEditor'
 export {

--- a/frontend/src/hooks/readFullEvent.ts
+++ b/frontend/src/hooks/readFullEvent.ts
@@ -1,6 +1,6 @@
 import { SerializedError } from '@reduxjs/toolkit'
 import { FetchBaseQueryError, skipToken } from '@reduxjs/toolkit/query'
-import { ALL_USERS, api } from 'app/services/bis'
+import { api } from 'app/services/bis'
 import type { FullEvent } from 'app/services/bisTypes'
 import { User } from 'app/services/bisTypes'
 
@@ -31,16 +31,16 @@ export const useReadFullEvent = (
     event?.main_organizer ? { id: event.main_organizer } : skipToken,
   )
   const otherOrganizersQuery = api.endpoints.readUsers.useQuery(
-    // @ts-ignore -- readUsers query param shape mismatch
-    event?.other_organizers
-      ? { id: event.other_organizers, pageSize: ALL_USERS }
+    event?.other_organizers && event.other_organizers.length > 0
+      ? // readEvent returns ids as strings before full users are resolved
+        { id: event.other_organizers as unknown as string[] }
       : skipToken,
   )
   const locationQuery = api.endpoints.readLocation.useQuery(
     event?.location ? { id: event.location } : skipToken,
   )
   const inquiriesQuery = api.endpoints.readEventFeedbackInquiries.useQuery(
-    eventId > 0 ? { eventId, pageSize: 1000 } : skipToken,
+    eventId > 0 ? { eventId } : skipToken,
   )
 
   const allQueries = [

--- a/frontend/src/hooks/readUnknownAndFullUsers.ts
+++ b/frontend/src/hooks/readUnknownAndFullUsers.ts
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query'
-import { ALL_USERS, api } from 'app/services/bis'
+import { api } from 'app/services/bis'
 import { User, UserSearch } from 'app/services/bisTypes'
 import { useMemo } from 'react'
 
@@ -24,9 +24,7 @@ export const useReadUnknownAndFullUsers = (
 
   const { data: fullUsers, ...fullUsersStatus } =
     api.endpoints.readUsers.useQuery(
-      searchIds && searchIds.length > 0
-        ? { _search_id: searchIds, pageSize: ALL_USERS }
-        : skipToken,
+      searchIds && searchIds.length > 0 ? { _search_id: searchIds } : skipToken,
     )
 
   const combinedUsers: (UserSearch | User)[] | undefined =

--- a/frontend/src/hooks/useAllowedToCreateEvent.ts
+++ b/frontend/src/hooks/useAllowedToCreateEvent.ts
@@ -8,7 +8,9 @@ import { useCurrentUser } from './currentUser'
 export const useAllowedToCreateEvent = () => {
   const { data: currentUser, isLoading: isLoadingUser } = useCurrentUser()
   const { data: allQualifications, isLoading } =
-    api.endpoints.readQualifications.useQuery(currentUser ? {} : skipToken)
+    api.endpoints.readQualifications.useQuery(
+      currentUser ? undefined : skipToken,
+    )
 
   const canAddNewEvent =
     currentUser &&

--- a/frontend/src/org/components/EventForm/EventForm.tsx
+++ b/frontend/src/org/components/EventForm/EventForm.tsx
@@ -397,16 +397,17 @@ export const EventForm: FC<{
 
   // we're loading these to make sure that we have the data before we try to render the form, to make sure that the default values are properly initialized
   // TODO check whether this is necessary
-  const { data: categories } = api.endpoints.readEventCategories.useQuery()
-  const { data: groups } = api.endpoints.readEventGroups.useQuery()
-  const { data: programs } = api.endpoints.readPrograms.useQuery()
-  const { data: intendedFor } = api.endpoints.readIntendedFor.useQuery()
-  const { data: diets } = api.endpoints.readDiets.useQuery()
+  const { data: categories } =
+    api.endpoints.readEventCategories.useQuery(undefined)
+  const { data: groups } = api.endpoints.readEventGroups.useQuery(undefined)
+  const { data: programs } = api.endpoints.readPrograms.useQuery(undefined)
+  const { data: intendedFor } =
+    api.endpoints.readIntendedFor.useQuery(undefined)
+  const { data: diets } = api.endpoints.readDiets.useQuery(undefined)
   const { data: administrationUnits } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
-  const { data: allQualifications } = api.endpoints.readQualifications.useQuery(
-    {},
-  )
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
+  const { data: allQualifications } =
+    api.endpoints.readQualifications.useQuery(undefined)
 
   const cancelPersist = useClearPersistentForm('event', id)
 

--- a/frontend/src/org/components/EventForm/steps/BasicInfoStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/BasicInfoStep.tsx
@@ -29,11 +29,12 @@ export const BasicInfoStep = ({
   const { data: currentUser } = useCurrentUser()
 
   const { register, control, getValues, watch, trigger, formState } = methods
-  const { data: categories } = api.endpoints.readEventCategories.useQuery()
-  const { data: programs } = api.endpoints.readPrograms.useQuery()
+  const { data: categories } =
+    api.endpoints.readEventCategories.useQuery(undefined)
+  const { data: programs } = api.endpoints.readPrograms.useQuery(undefined)
   const { data: administrationUnits } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
-  const { data: tags } = api.endpoints.readEventTags.useQuery()
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
+  const { data: tags } = api.endpoints.readEventTags.useQuery(undefined)
 
   // trigger validation of fields which are dependent on other fields
   useEffect(() => {

--- a/frontend/src/org/components/EventForm/steps/EventGroupStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/EventGroupStep.tsx
@@ -20,7 +20,7 @@ export const EventGroupStep = ({
 }: {
   methods: MethodsShapes['group']
 }) => {
-  const { data: groups } = api.endpoints.readEventGroups.useQuery()
+  const { data: groups } = api.endpoints.readEventGroups.useQuery(undefined)
   return (
     <>
       <FormProvider {...methods}>

--- a/frontend/src/org/components/EventForm/steps/IntendedForStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/IntendedForStep.tsx
@@ -25,7 +25,8 @@ export const IntendedForStep = ({
   isCamp: boolean
   hasVIPPropagationOption: boolean
 }) => {
-  const { data: intendedFor } = api.endpoints.readIntendedFor.useQuery()
+  const { data: intendedFor } =
+    api.endpoints.readIntendedFor.useQuery(undefined)
   const { watch, register, trigger, control, unregister, setValue, formState } =
     methods
 

--- a/frontend/src/org/components/EventForm/steps/OrganizerStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/OrganizerStep.tsx
@@ -55,9 +55,8 @@ export const OrganizerStep = ({
   isInternalSectionMeeting: boolean
 }) => {
   const { control, watch, trigger, register, setValue, getValues } = methods
-  const { data: allQualifications } = api.endpoints.readQualifications.useQuery(
-    {},
-  )
+  const { data: allQualifications } =
+    api.endpoints.readQualifications.useQuery(undefined)
 
   const { data: currentUser } = useCurrentUser()
 

--- a/frontend/src/org/components/EventForm/steps/ParticipantsStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/ParticipantsStep.tsx
@@ -73,7 +73,6 @@ export const ParticipantsStep: FC<{
 
   const { data: participants } = api.endpoints.readEventParticipants.useQuery({
     eventId: event.id,
-    pageSize: 10000,
   })
 
   const addParticipant = async (newParticipantId: string) => {

--- a/frontend/src/org/components/EventForm/steps/PropagationStep.tsx
+++ b/frontend/src/org/components/EventForm/steps/PropagationStep.tsx
@@ -55,7 +55,7 @@ export const PropagationStep = ({
   isInternalSectionMeeting: boolean
 }) => {
   const { control, register, getValues, watch, trigger } = methods
-  const { data: diets } = api.endpoints.readDiets.useQuery()
+  const { data: diets } = api.endpoints.readDiets.useQuery(undefined)
 
   // revalidate ages when they change
   useEffect(() => {

--- a/frontend/src/org/components/EventForm/steps/registration/AddParticipantModal.tsx
+++ b/frontend/src/org/components/EventForm/steps/registration/AddParticipantModal.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { skipToken } from '@reduxjs/toolkit/dist/query'
-import { ALL_USERS, api } from 'app/services/bis'
+import { api } from 'app/services/bis'
 import {
   EventApplication,
   User,
@@ -92,22 +92,21 @@ export const AddParticipantModal: FC<INewApplicationModalProps> = ({
     birthday: string
   }>({ first_name: '', last_name: '', birthday: '' })
 
-  const { data: categories } = api.endpoints.readEventCategories.useQuery()
+  const { data: categories } =
+    api.endpoints.readEventCategories.useQuery(undefined)
   const { data: administrationUnits } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
 
   const { reset } = methods
 
   const { data: userOptions1, isFetching: isOptionsLoading1 } =
     api.endpoints.readUsers.useQuery({
       search: `${defaultUserData.first_name} ${defaultUserData.last_name}`,
-      pageSize: ALL_USERS,
     })
 
   const { data: userOptions2, isFetching: isOptionsLoading2 } =
     api.endpoints.readUsers.useQuery({
       search: `${defaultUserData.email?.split('@')[0]}`,
-      pageSize: ALL_USERS,
     })
 
   const { data: userOptions3, isFetching: isOptionsLoading3 } =
@@ -115,7 +114,6 @@ export const AddParticipantModal: FC<INewApplicationModalProps> = ({
       defaultUserData && defaultUserData.nickname
         ? {
             search: `${defaultUserData.nickname}`,
-            pageSize: ALL_USERS,
           }
         : skipToken,
     )

--- a/frontend/src/org/components/EventForm/steps/registration/Applications.tsx
+++ b/frontend/src/org/components/EventForm/steps/registration/Applications.tsx
@@ -123,13 +123,12 @@ export const Applications: FC<{
     })
 
   const { data: membershipCategories } =
-    api.endpoints.readMembershipCategories.useQuery({})
+    api.endpoints.readMembershipCategories.useQuery(undefined)
   const { data: administrationUnitsData } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
 
   const { data: participants } = api.endpoints.readEventParticipants.useQuery({
     eventId: event.id,
-    pageSize: 10000,
   })
 
   const { data: currentApplication } =
@@ -149,14 +148,11 @@ export const Applications: FC<{
 
   const applications = applicationsData ? applicationsData.results : []
 
+  const applicationUserIds = applications
+    .map(application => application.user)
+    .filter(isString)
   const { data: applicationUsersData } = api.endpoints.readUsers.useQuery(
-    applicationsData
-      ? {
-          id: applications
-            .map(application => application.user)
-            .filter(isString),
-        }
-      : skipToken,
+    applicationUserIds.length > 0 ? { id: applicationUserIds } : skipToken,
   )
   const applicationUsers = applicationUsersData?.results ?? []
 

--- a/frontend/src/org/components/EventForm/steps/registration/Participants.tsx
+++ b/frontend/src/org/components/EventForm/steps/registration/Participants.tsx
@@ -59,7 +59,7 @@ export const Participants: FC<{
   updateUser,
 }) => {
   const { data: participants, isLoading: isReadParticipantsLoading } =
-    api.endpoints.readEventParticipants.useQuery({ eventId, pageSize: 10000 })
+    api.endpoints.readEventParticipants.useQuery({ eventId })
 
   const [showShowApplicationModal, setShowShowApplicationModal] =
     useState<boolean>(false)
@@ -70,10 +70,10 @@ export const Participants: FC<{
   const [currentParticipantId, setCurrentParticipantId] = useState<string>()
   const [selectedUser, setSelectedUser] = useState<User | null>(null)
   const { data: membershipCategories } =
-    api.endpoints.readMembershipCategories.useQuery({})
+    api.endpoints.readMembershipCategories.useQuery(undefined)
 
   const { data: administrationUnits } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
 
   const { data: currentParticipant } = api.endpoints.readUser.useQuery(
     currentParticipantId ? { id: currentParticipantId } : skipToken,

--- a/frontend/src/org/components/EventForm/steps/registration/ParticipantsStats.tsx
+++ b/frontend/src/org/components/EventForm/steps/registration/ParticipantsStats.tsx
@@ -18,7 +18,6 @@ export const ParticipantsStats: FC<{
   const { data: participantsData, isLoading: isReadParticipantsLoading } =
     api.endpoints.readEventParticipants.useQuery({
       eventId: event.id,
-      pageSize: 10000,
     })
 
   const applications = applicationsData ? applicationsData.results : []

--- a/frontend/src/org/components/ImportParticipants/ImportParticipantsList/ImportParticipantsList.tsx
+++ b/frontend/src/org/components/ImportParticipants/ImportParticipantsList/ImportParticipantsList.tsx
@@ -176,7 +176,7 @@ const RowWithForm = ({
       : skipToken,
   )
   const { data: healthInsuranceCompanies } =
-    api.endpoints.readHealthInsuranceCompanies.useQuery({})
+    api.endpoints.readHealthInsuranceCompanies.useQuery(undefined)
 
   // here, we keep current user data
   const [currentData, setCurrentData] = useState<ConfirmedUser>()

--- a/frontend/src/org/components/OpportunityForm/OpportunityForm.tsx
+++ b/frontend/src/org/components/OpportunityForm/OpportunityForm.tsx
@@ -76,10 +76,7 @@ export const OpportunityForm = ({
   const { data: defaultContactPerson } = useCurrentUser()
 
   const { data: opportunityCategories } =
-    api.endpoints.readOpportunityCategories.useQuery({
-      page: 1,
-      pageSize: 1000,
-    })
+    api.endpoints.readOpportunityCategories.useQuery(undefined)
 
   const cancelPersist = useClearPersistentForm('opportunity', id)
 

--- a/frontend/src/org/pages/CloseEvent/CloseEvent.tsx
+++ b/frontend/src/org/pages/CloseEvent/CloseEvent.tsx
@@ -31,10 +31,7 @@ export const CloseEvent = () => {
     eventId,
   })
   const { data: inquiries } = api.endpoints.readEventFeedbackInquiries.useQuery(
-    {
-      eventId,
-      pageSize: 1000, // TODO is there a better way to load all?
-    },
+    { eventId },
   )
 
   const showMessage = useShowMessage()

--- a/frontend/src/org/pages/CreateEvent.tsx
+++ b/frontend/src/org/pages/CreateEvent.tsx
@@ -41,7 +41,8 @@ export const CreateEvent = () => {
     error: eventToCloneError,
   } = useReadFullEvent(cloneEventId)
 
-  const { data: categories } = api.endpoints.readEventCategories.useQuery()
+  const { data: categories } =
+    api.endpoints.readEventCategories.useQuery(undefined)
 
   const [createEvent, createEventStatus] =
     api.endpoints.createEvent.useMutation()

--- a/frontend/src/org/pages/EventFeedback/EventFeedback.tsx
+++ b/frontend/src/org/pages/EventFeedback/EventFeedback.tsx
@@ -13,7 +13,7 @@ export const EventFeedback: FC<{ event: FullEvent }> = ({ event }) => {
     eventId: event.id,
   })
   const { data: inquiries } = api.endpoints.readEventFeedbackInquiries.useQuery(
-    { eventId: event.id, pageSize: 1000 }, // TODO is there a better way to load all?
+    { eventId: event.id },
   )
   const [displayedFeedback, setDisplayedFeedback] = useState<
     EventFeedbackRead | undefined

--- a/frontend/src/org/pages/EventList/AllEvents.tsx
+++ b/frontend/src/org/pages/EventList/AllEvents.tsx
@@ -1,18 +1,32 @@
-import type { PaginatedList } from 'app/services/bisTypes'
-import { Event } from 'app/services/bisTypes'
-import { UnscalablePaginatedList } from 'components'
+import { skipToken } from '@reduxjs/toolkit/dist/query'
+import { api } from 'app/services/bis'
+import { Loading, PAGINATED_LIST_PAGE_SIZE, PaginatedList } from 'components'
+import { useCurrentUser } from 'hooks/currentUser'
+import { useSearchParamsState } from 'hooks/searchParamsState'
 import { useTitle } from 'hooks/title'
 import { EventTable } from 'org/components'
-import { useOutletContext } from 'react-router-dom'
 
 export const AllEvents = () => {
   useTitle('Moje akce')
-  const events = useOutletContext<PaginatedList<Event>>()
+  const { data: currentUser } = useCurrentUser()
+  const [page, setPage] = useSearchParamsState('s', 1, Number)
+
+  const { data: events } = api.endpoints.readOrganizedEvents.useQuery(
+    currentUser
+      ? { userId: currentUser.id, page, pageSize: PAGINATED_LIST_PAGE_SIZE }
+      : skipToken,
+  )
+
+  if (!events) return <Loading>Stahujeme akce...</Loading>
 
   return (
-    <UnscalablePaginatedList
+    <PaginatedList
       table={EventTable}
-      data={events.results ?? []}
+      data={events.results}
+      totalCount={events.count}
+      page={page}
+      pageSize={PAGINATED_LIST_PAGE_SIZE}
+      onPageChange={setPage}
       columnsToHideOnMobile={[3, 4]}
     />
   )

--- a/frontend/src/org/pages/EventList/EventsLayout.tsx
+++ b/frontend/src/org/pages/EventList/EventsLayout.tsx
@@ -1,15 +1,10 @@
-import { skipToken } from '@reduxjs/toolkit/dist/query'
-import { api } from 'app/services/bis'
-import { ListHeader, Loading } from 'components'
+import { ListHeader } from 'components'
 import listStyles from 'components/ListHeader/ListHeader.module.scss'
-import { useCurrentUser } from 'hooks/currentUser'
 import { ClearPageMargin, Content, Header, Layout } from 'layout/Layout'
 import { useMemo } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 
 export const EventsLayout = () => {
-  const { data: currentUser } = useCurrentUser()
-
   const location = useLocation()
 
   const pathnameThemes = useMemo(
@@ -23,12 +18,6 @@ export const EventsLayout = () => {
   )
 
   const theme = pathnameThemes[location.pathname as keyof typeof pathnameThemes]
-
-  const { data: events } = api.endpoints.readOrganizedEvents.useQuery(
-    currentUser
-      ? { userId: currentUser.id, page: 1, pageSize: 10000 } // fetch all and don't worry about it anymore
-      : skipToken,
-  )
 
   return (
     <ClearPageMargin style={{ height: '100%' }}>
@@ -53,13 +42,9 @@ export const EventsLayout = () => {
           />
         </Header>
         <Content>
-          {events?.results ? (
-            <div className={listStyles.listContent}>
-              <Outlet context={events} />
-            </div>
-          ) : (
-            <Loading>Stahujeme akce...</Loading>
-          )}
+          <div className={listStyles.listContent}>
+            <Outlet />
+          </div>
         </Content>
       </Layout>
     </ClearPageMargin>

--- a/frontend/src/org/pages/EventList/UnfinishedEvents.tsx
+++ b/frontend/src/org/pages/EventList/UnfinishedEvents.tsx
@@ -1,26 +1,39 @@
-import type { PaginatedList } from 'app/services/bisTypes'
-import { Event } from 'app/services/bisTypes'
-import { UnscalablePaginatedList } from 'components'
+import { skipToken } from '@reduxjs/toolkit/dist/query'
+import { api } from 'app/services/bis'
+import { Loading, PAGINATED_LIST_PAGE_SIZE, PaginatedList } from 'components'
+import { useCurrentUser } from 'hooks/currentUser'
+import { useSearchParamsState } from 'hooks/searchParamsState'
 import { useTitle } from 'hooks/title'
 import { EventTable } from 'org/components'
-import { useOutletContext } from 'react-router-dom'
 
 export const UnfinishedEvents = () => {
   useTitle('Moje nevyplněné akce')
-  const events = useOutletContext<PaginatedList<Event>>()
+  const { data: currentUser } = useCurrentUser()
+  const [page, setPage] = useSearchParamsState('s', 1, Number)
 
-  // here we want events that haven't been finished, and are not drafts
-  // TODO we'll need info from api what's draft and what's done
-  // for now we just show the events without record
-
-  const inputEvents = (events.results ?? []).filter(
-    event => !event.is_archived && !event.is_closed && !event.is_canceled,
+  const { data: events } = api.endpoints.readOrganizedEvents.useQuery(
+    currentUser
+      ? {
+          userId: currentUser.id,
+          page,
+          pageSize: PAGINATED_LIST_PAGE_SIZE,
+          is_archived: false,
+          is_closed: false,
+          is_canceled: false,
+        }
+      : skipToken,
   )
 
+  if (!events) return <Loading>Stahujeme akce...</Loading>
+
   return (
-    <UnscalablePaginatedList
+    <PaginatedList
       table={EventTable}
-      data={inputEvents}
+      data={events.results}
+      totalCount={events.count}
+      page={page}
+      pageSize={PAGINATED_LIST_PAGE_SIZE}
+      onPageChange={setPage}
       action="finish"
       columnsToHideOnMobile={[3, 4]}
     />

--- a/frontend/src/org/pages/Home/Home.tsx
+++ b/frontend/src/org/pages/Home/Home.tsx
@@ -36,7 +36,8 @@ const buttons: HomeButtonConfig[] = [
 export const Home = () => {
   useTitle('Organizátorský přístup')
   const [canCreateEvent] = useAllowedToCreateEvent()
-  const { data: dashboardItems } = api.endpoints.readDashboardItems.useQuery()
+  const { data: dashboardItems } =
+    api.endpoints.readDashboardItems.useQuery(undefined)
 
   const processedButtons = useMemo(() => {
     if (canCreateEvent) {

--- a/frontend/src/org/pages/OpportunityList/OpportunityList.tsx
+++ b/frontend/src/org/pages/OpportunityList/OpportunityList.tsx
@@ -4,11 +4,13 @@ import {
   InfoMessage,
   ListHeader,
   Loading,
-  UnscalablePaginatedList,
+  PAGINATED_LIST_PAGE_SIZE,
+  PaginatedList,
 } from 'components'
 import listStyles from 'components/ListHeader/ListHeader.module.scss'
 import * as opportunityTexts from 'config/static/opportunity'
 import { useCurrentUser } from 'hooks/currentUser'
+import { useSearchParamsState } from 'hooks/searchParamsState'
 import { useTitle } from 'hooks/title'
 import { ClearPageMargin, Content, Header, Layout } from 'layout/Layout'
 import { OpportunityTable } from 'org/components/OpportunityTable'
@@ -18,12 +20,12 @@ import { ExternalButtonLink } from 'components/Button/Button'
 export const OpportunityList = () => {
   useTitle('Příležitosti')
   const { data: currentUser } = useCurrentUser()
-  // it's safe to assume that the user is already loaded
   const userId = currentUser!.id
+  const [page, setPage] = useSearchParamsState('s', 1, Number)
   const { data: opportunities } = api.endpoints.readOpportunities.useQuery({
     userId,
-    page: 1,
-    pageSize: 10000,
+    page,
+    pageSize: PAGINATED_LIST_PAGE_SIZE,
   })
 
   return (
@@ -56,8 +58,12 @@ export const OpportunityList = () => {
         </InfoMessage>
         <Content>
           {opportunities ? (
-            <UnscalablePaginatedList
+            <PaginatedList
               data={opportunities.results}
+              totalCount={opportunities.count}
+              page={page}
+              pageSize={PAGINATED_LIST_PAGE_SIZE}
+              onPageChange={setPage}
               table={OpportunityTable}
               className={listStyles.listContent}
             />

--- a/frontend/src/org/pages/UpdateEvent.tsx
+++ b/frontend/src/org/pages/UpdateEvent.tsx
@@ -37,7 +37,8 @@ export const UpdateEvent = () => {
   // TODO maybe: add star when data are unsaved (also persistent data)
   useTitle(event ? `Upravit akci ${event.name}` : 'Upravit akci')
 
-  const { data: categories } = api.endpoints.readEventCategories.useQuery()
+  const { data: categories } =
+    api.endpoints.readEventCategories.useQuery(undefined)
 
   const [updateEvent, { error: updateEventError }] =
     api.endpoints.updateEvent.useMutation()

--- a/frontend/src/org/pages/ViewEvent/ViewEvent.tsx
+++ b/frontend/src/org/pages/ViewEvent/ViewEvent.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/dist/query'
-import { ALL_USERS, api } from 'app/services/bis'
+import { api } from 'app/services/bis'
 import {
   Actions,
   Breadcrumbs,
@@ -48,11 +48,11 @@ export const ViewEvent = ({ readonly }: { readonly?: boolean }) => {
   useTitle(`Akce ${event?.name ?? ''}`)
 
   const { data: administrationUnits } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
 
   const { data: participants } = api.endpoints.readUsers.useQuery(
     event.record?.participants && event.record.participants.length > 0
-      ? { id: event.record.participants, pageSize: ALL_USERS }
+      ? { id: event.record.participants }
       : skipToken,
   )
 

--- a/frontend/src/user/UserEventsLayout.tsx
+++ b/frontend/src/user/UserEventsLayout.tsx
@@ -1,20 +1,9 @@
-import { skipToken } from '@reduxjs/toolkit/dist/query'
-import { api } from 'app/services/bis'
 import { ListHeader } from 'components'
 import listStyles from 'components/ListHeader/ListHeader.module.scss'
-import { useCurrentUser } from 'hooks/currentUser'
 import { ClearPageMargin, Content, Header, Layout } from 'layout/Layout'
 import { Outlet } from 'react-router-dom'
 
 export const UserEventsLayout = () => {
-  const { data: currentUser } = useCurrentUser()
-
-  const { data: events } = api.endpoints.readOrganizedEvents.useQuery(
-    currentUser
-      ? { userId: currentUser.id, page: 1, pageSize: 10000 } // fetch all and don't worry about it anymore
-      : skipToken,
-  )
-
   return (
     <ClearPageMargin style={{ height: '100%' }}>
       <Layout>
@@ -38,7 +27,7 @@ export const UserEventsLayout = () => {
         </Header>
         <Content>
           <div className={listStyles.listContent}>
-            <Outlet context={events} />
+            <Outlet />
           </div>
         </Content>
       </Layout>

--- a/frontend/src/user/pages/UserParticipatedEvents.tsx
+++ b/frontend/src/user/pages/UserParticipatedEvents.tsx
@@ -1,23 +1,30 @@
 import { api } from 'app/services/bis'
 import type { Event } from 'app/services/bisTypes'
-import { Loading, UnscalablePaginatedList } from 'components'
+import { Loading, PAGINATED_LIST_PAGE_SIZE, PaginatedList } from 'components'
 import { useCurrentUser } from 'hooks/currentUser'
+import { useSearchParamsState } from 'hooks/searchParamsState'
 import { useTitle } from 'hooks/title'
 import { UserEventTable } from 'user/UserEventTable'
 
 export const UserParticipatedEvents = () => {
   useTitle('Akce kterých jsem se zúčastnil/a')
   const { data: currentUser } = useCurrentUser()
+  const [page, setPage] = useSearchParamsState('s', 1, Number)
   const { data: events } = api.endpoints.readParticipatedEvents.useQuery({
     userId: currentUser!.id,
-    pageSize: 10000,
+    page,
+    pageSize: PAGINATED_LIST_PAGE_SIZE,
   })
 
   if (!events) return <Loading>Nahráváme akce</Loading>
 
   return (
-    <UnscalablePaginatedList<Event>
+    <PaginatedList<Event>
       data={events.results}
+      totalCount={events.count}
+      page={page}
+      pageSize={PAGINATED_LIST_PAGE_SIZE}
+      onPageChange={setPage}
       table={UserEventTable}
     />
   )

--- a/frontend/src/user/pages/UserRegisteredEvents.tsx
+++ b/frontend/src/user/pages/UserRegisteredEvents.tsx
@@ -1,23 +1,30 @@
 import { api } from 'app/services/bis'
 import type { Event } from 'app/services/bisTypes'
-import { Loading, UnscalablePaginatedList } from 'components'
+import { Loading, PAGINATED_LIST_PAGE_SIZE, PaginatedList } from 'components'
 import { useCurrentUser } from 'hooks/currentUser'
+import { useSearchParamsState } from 'hooks/searchParamsState'
 import { useTitle } from 'hooks/title'
 import { UserEventTable } from 'user/UserEventTable'
 
 export const UserRegisteredEvents = () => {
   useTitle('Akce na které jsem se přihlásil/a')
   const { data: currentUser } = useCurrentUser()
+  const [page, setPage] = useSearchParamsState('s', 1, Number)
   const { data: events } = api.endpoints.readRegisteredEvents.useQuery({
     userId: currentUser!.id,
-    pageSize: 10000,
+    page,
+    pageSize: PAGINATED_LIST_PAGE_SIZE,
   })
 
   if (!events) return <Loading>Nahráváme akce</Loading>
 
   return (
-    <UnscalablePaginatedList<Event>
+    <PaginatedList<Event>
       data={events.results}
+      totalCount={events.count}
+      page={page}
+      pageSize={PAGINATED_LIST_PAGE_SIZE}
+      onPageChange={setPage}
       table={UserEventTable}
     />
   )

--- a/frontend/src/user/pages/ViewProfile/ViewProfile.tsx
+++ b/frontend/src/user/pages/ViewProfile/ViewProfile.tsx
@@ -24,7 +24,7 @@ export const ViewProfile = () => {
   const { data: currentUser } = useCurrentUser()
 
   const { data: administrationUnits } =
-    api.endpoints.readAdministrationUnits.useQuery({ pageSize: 2000 })
+    api.endpoints.readAdministrationUnits.useQuery(undefined)
 
   const isSelf = currentUser?.id === user.id
 


### PR DESCRIPTION
## Summary

The django container hit OOM (exit 137) because several frontend callers asked the backend for `page_size=10000` of heavy serializers (Events, Users, Applications, Participants, Locations). DRF rendered each request entirely in Python, peaking near the 900M limit.

This PR caps server-side pagination, replaces every "fetch everything" call with a parallel paginated loop, and switches the heavy table views to true server pagination.

## What changes

**Backend**
- `Pagination.max_page_size = 200`; `LightPagination(max=1000)` for slim/cached endpoints.
- Slim `LocationMapSerializer` + `for_map` action on `LocationViewSet` (id/name/gps only) for map markers.
- `AdministrationUnitViewSet` cached via `CachedViewSetMixin`; invalidated on save/delete.
- `EventFilter` gains `is_archived`/`is_closed`/`is_canceled` so `UnfinishedEvents` can filter server-side.
- `BISPermissions` recognises the new `for_map` action.

**Frontend**
- New `fetchAllPages` queryFn helper. Page 1 reveals `count`; pages 2..N fire in parallel. Optional `maxItems` cap for search-style endpoints.
- Every "fetch everything" endpoint migrated: categories, admin units, health insurance, locations, dashboard items, event applications/participants/photos/images/questions/feedbacks/inquiries/attendance pages, etc.
- Removed `UnscalablePaginatedList` (slice-after-fetch-all). The renamed `PaginatedList` now drives proper server pagination; `PAGINATED_LIST_PAGE_SIZE` shared between component and call sites.
- Event/Opportunity tables (AllEvents, UnfinishedEvents, UserParticipated/Registered, OpportunityList) now fetch one page at a time.
- `EventsLayout`/`UserEventsLayout` no longer pre-fetch events via Outlet (children fetched their own; `UserEventsLayout` was even pre-fetching the wrong endpoint).
- `SelectLocation` uses the slim `for_map` endpoint and lazy `readLocation` lookup on selection.
- `ALL_USERS` constant and `pageSize: 10000/2000/1000` literals removed.
- `readUsers` short-circuits when `id`/`_search_id` is empty; same guard at the call sites in `readFullEvent` and `Applications`. Without this, superusers triggered an unbounded all-users fetch when an event had no other organizers.

**Tests**
- `createEvent.cy.ts` intercepts loosened to path-only so they match the new URL shape (now always includes `page`/`page_size`).
- All cypress suites pass (`make test` green).

## Test plan
- [x] Type-check passes (`tsc --noEmit`)
- [x] `make test` green (backend pytest + frontend unit + frontend cypress + cookbook unit + cookbook cypress)
- [ ] Smoke test in staging: open events list, opportunity list, map picker, event detail edit
- [ ] Watch Sentry / `kubectl top pod` after deploy for memory pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)